### PR TITLE
Clones the project to be built down

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,2 +1,2 @@
 install:
-	mkdir ./dockers
+	mkdir ./launches

--- a/test/models/launch_test.rb
+++ b/test/models/launch_test.rb
@@ -3,17 +3,19 @@ require 'test_helper'
 class LaunchTest < ActiveSupport::TestCase
 
     setup do
-         url = 'https://github.com/docker-library/hello-world/blob/bdee60d7ff6b98037657dc34a10e9ca4ffd6785f/hello-world/Dockerfile'
+         url='https://github.com/dmitrinesterenko/how-we-deploy/blob/master/Dockerfile-rails'
          params = {'docker_file_url' => url}
         @launch = Launch.new(params)
     end
-    test 'gets the raw url' do
-        expected_url =
-'https://raw.githubusercontent.com/docker-library/hello-world/bdee60d7ff6b98037657dc34a10e9ca4ffd6785f/hello-world/Dockerfile'
-        assert_equal(@launch.docker_file_url, expected_url)
-    end
 
     test 'parses the application name correctly from the repo' do
-        assert_equal(@launch.program_name, 'hello-world')
+        assert_equal(@launch.program_name, 'how-we-deploy')
+    end
+
+    test 'downloads the application' do
+        @launch.save
+        assert_equal(@launch.application_remote_path, 'https://github.com/dmitrinesterenko/how-we-deploy')
+        assert_equal(@launch.application_local_path, './launches/how-we-deploy')
+        assert_equal(@launch.application_files.count, 29)
     end
 end


### PR DESCRIPTION
Deduce project name from the full path to the docker file
Build the docker image for the project in the right directory to have the right
context
Adds debugging methods to deal with logs of the builder later.

Addresses #4 